### PR TITLE
* first version of segmentation of regions into lines

### DIFF
--- a/ocrd/scripts/run.py
+++ b/ocrd/scripts/run.py
@@ -36,6 +36,12 @@ def cli(working_dir, mets_xml):
     page_segmenter.set_handle(initializer.get_handle())
     page_segmenter.segment()
 
+    # region segmentation
+    region_segmenter = segment.RegionSegmenter()
+    region_segmenter.set_handle(initializer.get_handle())
+    region_segmenter.segment()
+
     # output
     for ID in initializer.get_handle().page_trees:
         print(md.parseString(ET.tostring(initializer.get_handle().page_trees[ID].getroot(), encoding='utf8', method='xml')).toprettyxml(indent="\t"))
+        pass

--- a/ocrd/segment/__init__.py
+++ b/ocrd/segment/__init__.py
@@ -1,1 +1,2 @@
 from .segmenting import PageSegmenter
+from .segmenting import RegionSegmenter

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ pyexiftool
 tesserocr
 lxml
 Pillow
+numpy
+opencv-python


### PR DESCRIPTION
fixes #26 
fixes #25 

By now, line coordinates are estimated with respect to the surrounding text region. Not sure yet if this is PAGE-compliant. Tested with the sample images from https://github.com/OCR-D/spec. CLI works, e.g.,
```bash
$ run-ocrd ../spec/io/example/mets.xml
```
Would be great to hear your thoughts on that.