### PR TITLE
METS unique_identifier

### DIFF
--- a/ocrd/constants.py
+++ b/ocrd/constants.py
@@ -23,6 +23,9 @@ DEFAULT_REPOSITORY_URL = 'http://localhost:5000/'
 
 DEFAULT_CACHE_FOLDER = '/tmp/cache-pyocrd'
 
+FILE_GROUP_CATEGORIES = ['IMG', 'SEG', 'OCR', 'CORR']
+IDENTIFIER_PRIORITY = ['purl', 'urn', 'doi', 'url']
+
 TAG_METS_FILE = '{%s}file' % NAMESPACES['mets']
 TAG_METS_FLOCAT = '{%s}FLocat' % NAMESPACES['mets']
 TAG_METS_FILEGRP = '{%s}fileGrp' % NAMESPACES['mets']

--- a/ocrd/model/ocrd_mets.py
+++ b/ocrd/model/ocrd_mets.py
@@ -1,4 +1,4 @@
-from ocrd.constants import NAMESPACES as NS, TAG_METS_FILE, TAG_METS_FILEGRP
+from ocrd.constants import NAMESPACES as NS, TAG_METS_FILE, TAG_METS_FILEGRP, IDENTIFIER_PRIORITY
 
 from .ocrd_xml_base import OcrdXmlDocument, ET
 from .ocrd_file import OcrdFile
@@ -11,6 +11,13 @@ class OcrdMets(OcrdXmlDocument):
 
     def __str__(self):
         return 'OcrdMets[fileGrps=%s,files=%s]' % (self.file_groups, self.file_by_id)
+
+    @property
+    def unique_identifier(self):
+        for t in IDENTIFIER_PRIORITY:
+            found = self._tree.getroot().find('.//mods:identifier[@type="%s"]' % t, NS)
+            if found is not None:
+                return found.text
 
     @property
     def file_by_id(self):

--- a/test/model/test_ocrd_mets.py
+++ b/test/model/test_ocrd_mets.py
@@ -8,6 +8,9 @@ class TestOcrdMets(TestCase):
     def setUp(self):
         self.mets = OcrdMets(filename=METS_HEROLD)
 
+    def test_unique_identifier(self):
+        self.assertEqual(self.mets.unique_identifier, 'http://resolver.staatsbibliothek-berlin.de/SBB0000F29300010000', 'Right identifier')
+
     def test_file_groups(self):
         self.assertEqual(len(self.mets.file_groups), 17, '17 file groups')
 


### PR DESCRIPTION
Add a `unique_identifier` property to mets to get the mods:identifier according to spec.